### PR TITLE
set REST API endpointType to regional

### DIFF
--- a/task-list-service/serverless.yml
+++ b/task-list-service/serverless.yml
@@ -27,6 +27,7 @@ provider:
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'}
   region: ${env:TARGET_REGION}
+  endpointType: regional
   environment:
     TASK_TABLE: '${env:TASK_LIST_TASK_TABLE}-${self:provider.stage}'
   iamRoleStatements:


### PR DESCRIPTION
In China regions, API end point type EDGE is not yet supported.
Force set REST API endpointType to REGIONAL fow now.